### PR TITLE
Added some satellites that weren't assimilated in scout runs to enkf …

### DIFF
--- a/enkf_run.csh
+++ b/enkf_run.csh
@@ -147,7 +147,8 @@ cat <<EOF1 >! enkf.nml
   sattypes_rad(71)= 'avhrr_n15',     dsis(71)= 'avhrr3_n15',
   sattypes_rad(72)= 'avhrr_n16',     dsis(72)= 'avhrr3_n16',
   sattypes_rad(73)= 'avhrr_n17',     dsis(73)= 'avhrr3_n17',
-  
+  sattypes_rad(74)='amsua_n16',      dsis(74)= 'amsua_n16'
+  sattypes_rad(75)='amsub_n15',      dsis(75)= 'amsub_n15',  
  /
  &END
  &ozobs_enkf

--- a/run_gsi_4densvar.sh
+++ b/run_gsi_4densvar.sh
@@ -385,6 +385,7 @@ OBS_INPUT::
    sbuvbufr       sbuv2       n17         sbuv8_n17            0.0     0      0
    sbuvbufr       sbuv2       n18         sbuv8_n18            0.0     0      0
    sbuvbufr       sbuv2       n19         sbuv8_n19            0.0     0      0
+   hirs2bufr      hirs2       n11         hirs2_n11            0.0     1      1
    hirs2bufr      hirs2       n14         hirs2_n14            0.0     1      1
    hirs3bufr      hirs3       n15         hirs3_n15            0.0     1      1
    hirs3bufr      hirs3       n16         hirs3_n16            0.0     1      1
@@ -393,6 +394,7 @@ OBS_INPUT::
    gimgrbufr      goes_img    g11         imgr_g11             0.0     1      0
    gimgrbufr      goes_img    g12         imgr_g12             0.0     1      0
    airsbufr       airs        aqua        airs281SUBSET_aqua   0.0     1      1
+   msubufr        msu         n11         msu_n11              0.0     1      1
    msubufr        msu         n14         msu_n14              0.0     1      1
    ssubufr        ssu         n14         ssu_n14              0.0     1      1
    amsuabufr      amsua       n15         amsua_n15            0.0     1      1


### PR DESCRIPTION
Added HIRS2 N11 & MSU N11 to GSI namelist;
AMSUA N16 & AMSUB N15 to EnKF namelist.
Those obs weren't assimilated in GSI or EnKF in our scout runs due to missing from namelists.